### PR TITLE
Ui improvements

### DIFF
--- a/CustomerSupport/src/main/java/com/kennuware/customersupport/APIs.java
+++ b/CustomerSupport/src/main/java/com/kennuware/customersupport/APIs.java
@@ -67,7 +67,6 @@ public class APIs {
             JsonObject json = gson.fromJson(body, JsonObject.class);
             String returnID = json.get("returnID").toString();
             String status = json.get("status").toString();
-            returnID = returnID.substring(1,returnID.length()-1);
             status = status.substring(1,status.length()-1);
             return EmployeeService.changeStatus(returnID, status, session);
         }, gson::toJson);
@@ -95,7 +94,6 @@ public class APIs {
             JsonObject json = gson.fromJson(body, JsonObject.class);
             String returnID = json.get("returnID").toString();
             String itemID = json.get("itemID").toString();
-            returnID = returnID.substring(1,returnID.length()-1);
             return EmployeeService.resolve(returnID, itemID, session);
         }, gson::toJson);
 

--- a/CustomerSupport/src/main/java/com/kennuware/customersupport/services/EmployeeService.java
+++ b/CustomerSupport/src/main/java/com/kennuware/customersupport/services/EmployeeService.java
@@ -115,6 +115,7 @@ public class EmployeeService {
                 RefurbishService.reportItemRefurbished(Integer.parseInt(itemID), util);
             }
             r.setType(ReturnType.RESOLVED);
+            System.out.println("Setting return " + r.getID() + " to resolved.");
             session.save(r);
 
             Query q = session.getNamedQuery("findDateTrail").setString("returnsID", returnID);

--- a/react/app/components/ReturnModal/index.js
+++ b/react/app/components/ReturnModal/index.js
@@ -30,17 +30,17 @@ class ReturnModal extends React.Component { // eslint-disable-line react/prefer-
       actions = (
         <div>
           <Row>
-            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('REFUND')}>
+            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('refund')}>
               Refund
             </Button>
           </Row>
           <Row>
-            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('REFURBISH')}>
+            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('refurbish')}>
               Refurbish
             </Button>
           </Row>
           <Row>
-            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('DENY')}>
+            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('deny')}>
               Deny
             </Button>
           </Row>

--- a/react/app/components/ReturnModal/index.js
+++ b/react/app/components/ReturnModal/index.js
@@ -11,8 +11,53 @@ import { Modal, Button, Row, Col } from 'react-bootstrap';
 import styles from './styles.css';
 
 class ReturnModal extends React.Component { // eslint-disable-line react/prefer-stateless-function
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      requestStatus: 'REFURBISH',
+    };
+  }
+
   render() {
-    console.log('item', this.props.item);
+    let actions = (
+      <div>
+        There are no actions to take for this return.
+      </div>
+    );
+    if (this.props.item.type === 'PENDING') {
+      // Set to refund/refurbish/denied
+      actions = (
+        <div>
+          <Row>
+            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('REFUND')}>
+              Refund
+            </Button>
+          </Row>
+          <Row>
+            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('REFURBISH')}>
+              Refurbish
+            </Button>
+          </Row>
+          <Row>
+            <Button bsStyle="success" onClick={() => this.props.onSetRequestStatus('DENY')}>
+              Deny
+            </Button>
+          </Row>
+        </div>
+      );
+    } else if (this.props.item.type === 'REFUND' || this.props.item.type === 'REFURBISH') {
+      // Mark as received / Mark as resolved? Is there a type that supports this?
+      actions = (
+        <div>
+          <Button bsStyle="success" onClick={() => this.props.onResolveReturn()}>
+            Mark as Resolved
+          </Button>
+        </div>
+      );
+    } else {
+      // There are no actions to take
+    }
     return (
       <Modal show={this.props.show} onHide={this.close}>
         <Modal.Header>
@@ -55,7 +100,7 @@ class ReturnModal extends React.Component { // eslint-disable-line react/prefer-
               </Row>
             </Col>
             <Col md={6}>
-              Actions:
+              {actions}
             </Col>
           </Row>
         </Modal.Body>
@@ -71,6 +116,8 @@ ReturnModal.propTypes = {
   item: React.PropTypes.object,
   show: React.PropTypes.bool,
   cancel: React.PropTypes.func,
+  onSetRequestStatus: React.PropTypes.func,
+  onResolveReturn: React.PropTypes.func,
 };
 
 export default ReturnModal;

--- a/react/app/components/ReturnModal/index.js
+++ b/react/app/components/ReturnModal/index.js
@@ -6,22 +6,61 @@
 
 import React from 'react';
 
-import { Modal, Button } from 'react-bootstrap';
+import { Modal, Button, Row, Col } from 'react-bootstrap';
 
 import styles from './styles.css';
 
 class ReturnModal extends React.Component { // eslint-disable-line react/prefer-stateless-function
   render() {
+    console.log('item', this.props.item);
     return (
       <Modal show={this.props.show} onHide={this.close}>
         <Modal.Header>
-          <Modal.Title>Return Modal</Modal.Title>
+          <Modal.Title>Manage Return</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <p>You want to manage this return</p>
+          <Row>
+            <Col md={6}>
+              <Row>
+                <Col md={4} className={styles.labelText}>
+                  ID:
+                </Col>
+                <Col md={8}>
+                  {this.props.item.id}
+                </Col>
+              </Row>
+              <Row>
+                <Col md={4} className={styles.labelText}>
+                  Reason:
+                </Col>
+                <Col md={8}>
+                  {this.props.item.reason}
+                </Col>
+              </Row>
+              <Row>
+                <Col md={4} className={styles.labelText}>
+                  Status:
+                </Col>
+                <Col md={8}>
+                  {this.props.item.type}
+                </Col>
+              </Row>
+              <Row>
+                <Col md={4} className={styles.labelText}>
+                  Item ID:
+                </Col>
+                <Col md={4}>
+                  {this.props.item.itemID}
+                </Col>
+              </Row>
+            </Col>
+            <Col md={6}>
+              Actions:
+            </Col>
+          </Row>
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={this.props.cancel}>Cancel</Button>
+          <Button onClick={this.props.cancel}>Done</Button>
         </Modal.Footer>
       </Modal>
     );
@@ -29,6 +68,7 @@ class ReturnModal extends React.Component { // eslint-disable-line react/prefer-
 }
 
 ReturnModal.propTypes = {
+  item: React.PropTypes.object,
   show: React.PropTypes.bool,
   cancel: React.PropTypes.func,
 };

--- a/react/app/components/ReturnModal/styles.css
+++ b/react/app/components/ReturnModal/styles.css
@@ -1,3 +1,7 @@
 .returnModal { /* stylelint-disable */
 
 }
+
+.labelText {
+  font-weight: bold;
+}

--- a/react/app/components/ReturnTable/index.js
+++ b/react/app/components/ReturnTable/index.js
@@ -17,13 +17,13 @@ class ReturnTable extends React.Component {
 
   getContent() {
     return this.props.returns.map((item) =>
-      <tr key={item.id} className={styles.tableRow}>
-        <td className={styles.tableCell}>{item.id}</td>
-        <td className={styles.tableCell}>{item.itemID}</td>
-        <td className={styles.tableCell}>{item.reason}</td>
-        <td className={styles.tableCell}>{item.storeID}</td>
-        <td className={styles.tableCell}>{item.type}</td>
-        <td className={styles.tableCell}><Button onClick={() => this.props.onManageReturn(item)}>Manage</Button></td>
+      <tr key={item.id}>
+        <td>{item.id}</td>
+        <td>{item.itemID}</td>
+        <td>{item.reason}</td>
+        <td>{item.storeID}</td>
+        <td>{item.type}</td>
+        <td><Button onClick={() => this.props.onManageReturn(item)}>Manage</Button></td>
       </tr>
     );
   }
@@ -32,16 +32,20 @@ class ReturnTable extends React.Component {
     const content = this.getContent();
     return (
       <div className={styles.returnTable}>
-        <Table className={styles.displayTable}>
-          <tr className={styles.tableRow}>
-            <th className={styles.tableHeader}>ID</th>
-            <th className={styles.tableHeader}>Item Name</th>
-            <th className={styles.tableHeader}>Reason for Return</th>
-            <th className={styles.tableHeader}>Store ID</th>
-            <th className={styles.tableHeader}>Type</th>
-            <th className={styles.tableHeader}>Manage</th>
-          </tr>
-          {content}
+        <Table striped bordered condensed hover>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Item Name</th>
+              <th>Reason for Return</th>
+              <th>Store ID</th>
+              <th>Type</th>
+              <th>Manage</th>
+            </tr>
+          </thead>
+          <tbody>
+            {content}
+          </tbody>
         </Table>
       </div>
     );

--- a/react/app/components/ReturnTable/index.js
+++ b/react/app/components/ReturnTable/index.js
@@ -6,17 +6,30 @@
 
 import React from 'react';
 
-import { Table, Button } from 'react-bootstrap';
+import { Table, Button, Row, Col, Form, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
 
 import styles from './styles.css';
 
 class ReturnTable extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      displayedReturns: [],
+      filter: '',
+    };
+  }
+
   componentWillMount() {
     this.props.getReturns();
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({ displayedReturns: nextProps.returns });
+  }
+
   getContent() {
-    return this.props.returns.map((item) =>
+    return this.state.displayedReturns.map((item) =>
       <tr key={item.id}>
         <td>{item.id}</td>
         <td>{item.itemID}</td>
@@ -28,10 +41,47 @@ class ReturnTable extends React.Component {
     );
   }
 
+  filterReturns(filterText) {
+    let newReturns = [];
+    console.log('filtering');
+
+    if (filterText !== '') {
+      for (let i = 0; i < this.props.returns.length; i++) {
+        const item = this.props.returns[i];
+        if (!isNaN(filterText)) {
+          if (item.id === parseInt(filterText, 10)) {
+            newReturns.push(item);
+          }
+        } else if (item.itemID.toLowerCase().includes(filterText.toLowerCase()) || item.type.toLowerCase().includes(filterText.toLowerCase()) || item.reason.toLowerCase().includes(filterText.toLowerCase())) {
+          newReturns.push(item);
+        }
+      }
+    } else {
+      newReturns = this.props.returns;
+    }
+
+    return newReturns;
+  }
+
+  updateFilter(evt) {
+    this.setState({ filter: evt.target.value });
+    this.setState({ displayedReturns: this.filterReturns(evt.target.value) });
+  }
+
   render() {
     const content = this.getContent();
     return (
       <div className={styles.returnTable}>
+        <Row style={{ marginBottom: '20px' }}>
+          <Col md={6}>
+            <Form inline>
+              <FormGroup controlId="formInlineName">
+                <ControlLabel>Filter Results:</ControlLabel>
+                <FormControl type="text" placeholder="filter" value={this.state.filter} onChange={(evt) => this.updateFilter(evt)}/>
+              </FormGroup>
+            </Form>
+          </Col>
+        </Row>
         <Table striped bordered condensed hover>
           <thead>
             <tr>

--- a/react/app/containers/CustSupportAgent/actions.js
+++ b/react/app/containers/CustSupportAgent/actions.js
@@ -26,6 +26,8 @@ import {
 
   MANAGE_RETURN,
   CANCEL_MANAGE_RETURN,
+  SET_RETURN_STATUS,
+  RESOLVE_RETURN,
 } from './constants';
 
 export function gotoNewReturn() {
@@ -129,5 +131,18 @@ export function manageReturn(item) {
 export function cancelManageReturn() {
   return {
     type: CANCEL_MANAGE_RETURN,
+  };
+}
+
+export function setReturnStatus(status) {
+  return {
+    type: SET_RETURN_STATUS,
+    status,
+  };
+}
+
+export function resolveReturn() {
+  return {
+    type: RESOLVE_RETURN,
   };
 }

--- a/react/app/containers/CustSupportAgent/actions.js
+++ b/react/app/containers/CustSupportAgent/actions.js
@@ -27,7 +27,11 @@ import {
   MANAGE_RETURN,
   CANCEL_MANAGE_RETURN,
   SET_RETURN_STATUS,
+  SET_RETURN_STATUS_ERROR,
+  SET_RETURN_STATUS_SUCCESS,
   RESOLVE_RETURN,
+  RESOLVE_RETURN_ERROR,
+  RESOLVE_RETURN_SUCCESS,
 } from './constants';
 
 export function gotoNewReturn() {
@@ -141,8 +145,36 @@ export function setReturnStatus(status) {
   };
 }
 
+export function setRequestStatusSuccess(data) {
+  return {
+    type: SET_RETURN_STATUS_SUCCESS,
+    data,
+  };
+}
+
+export function setRequestStatusError() {
+  return {
+    type: SET_RETURN_STATUS_ERROR,
+  };
+}
+
 export function resolveReturn() {
   return {
     type: RESOLVE_RETURN,
   };
 }
+
+export function resolveReturnSuccess(data) {
+  return {
+    type: RESOLVE_RETURN_SUCCESS,
+    data,
+  };
+}
+
+export function resolveReturnError() {
+  return {
+    type: RESOLVE_RETURN_ERROR,
+  };
+}
+
+

--- a/react/app/containers/CustSupportAgent/constants.js
+++ b/react/app/containers/CustSupportAgent/constants.js
@@ -26,6 +26,10 @@ export const GET_RETURNS_ERROR = 'app/CustSupportAgent/GET_RETURNS_ERROR';
 export const MANAGE_RETURN = 'app/CustSupportAgent/MANAGE_RETURN';
 export const CANCEL_MANAGE_RETURN = 'app/CustSupportAgent/CANCEL_MANAGE_RETURN';
 export const SET_RETURN_STATUS = 'app/CustSupportAgent/SET_RETURN_STATUS';
+export const SET_RETURN_STATUS_SUCCESS = 'app/CustSupportAgent/SET_RETURN_STATUS_SUCCESS';
+export const SET_RETURN_STATUS_ERROR = 'app/CustSupportAgent/SET_RETURN_STATUS_ERROR';
 export const RESOLVE_RETURN = 'app/CustSupportAgent/RESOLVE_RETURN';
+export const RESOLVE_RETURN_SUCCESS = 'app/CustSupportAgent/RESOLVE_RETURN_SUCCESS';
+export const RESOLVE_RETURN_ERROR = 'app/CustSupportAgent/RESOLVE_RETURN_ERROR';
 
 export const AGENT = 'AGENT';

--- a/react/app/containers/CustSupportAgent/constants.js
+++ b/react/app/containers/CustSupportAgent/constants.js
@@ -25,5 +25,7 @@ export const GET_RETURNS_ERROR = 'app/CustSupportAgent/GET_RETURNS_ERROR';
 
 export const MANAGE_RETURN = 'app/CustSupportAgent/MANAGE_RETURN';
 export const CANCEL_MANAGE_RETURN = 'app/CustSupportAgent/CANCEL_MANAGE_RETURN';
+export const SET_RETURN_STATUS = 'app/CustSupportAgent/SET_RETURN_STATUS';
+export const RESOLVE_RETURN = 'app/CustSupportAgent/RESOLVE_RETURN';
 
 export const AGENT = 'AGENT';

--- a/react/app/containers/CustSupportAgent/index.js
+++ b/react/app/containers/CustSupportAgent/index.js
@@ -48,6 +48,7 @@ export class CustSupportAgent extends React.Component { // eslint-disable-line r
     let content = (<div>Hello</div>);
     const returnModal = (
       <ReturnModal
+        item={this.props.page.returnItem}
         show={this.props.page.managingReturn}
         cancel={this.props.onCancelManage}
       />

--- a/react/app/containers/CustSupportAgent/index.js
+++ b/react/app/containers/CustSupportAgent/index.js
@@ -29,6 +29,8 @@ import {
   getReturns,
   manageReturn,
   cancelManageReturn,
+  setReturnStatus,
+  resolveReturn,
 
   submitReturn,
 } from './actions';
@@ -51,6 +53,8 @@ export class CustSupportAgent extends React.Component { // eslint-disable-line r
         item={this.props.page.returnItem}
         show={this.props.page.managingReturn}
         cancel={this.props.onCancelManage}
+        onSetRequestStatus={this.props.onSetRequestStatus}
+        onResolveReturn={this.props.onResolveReturn}
       />
     );
     const successModal = (
@@ -151,6 +155,9 @@ CustSupportAgent.propTypes = {
   onManageReturn: React.PropTypes.func,
   onCancelManage: React.PropTypes.func,
 
+  onSetRequestStatus: React.PropTypes.func,
+  onResolveReturn: React.PropTypes.func,
+
   onSignOut: React.PropTypes.func,
 };
 
@@ -176,6 +183,9 @@ function mapDispatchToProps(dispatch) {
     onGetReturns: () => dispatch(getReturns()),
     onManageReturn: (item) => dispatch(manageReturn(item)),
     onCancelManage: () => dispatch(cancelManageReturn()),
+
+    onSetRequestStatus: (status) => dispatch(setReturnStatus(status)),
+    onResolveReturn: () => dispatch(resolveReturn()),
 
     onSignOut: () => dispatch(signOut()),
 

--- a/react/app/containers/CustSupportAgent/reducer.js
+++ b/react/app/containers/CustSupportAgent/reducer.js
@@ -22,6 +22,7 @@ import {
 
   MANAGE_RETURN,
   CANCEL_MANAGE_RETURN,
+  SET_RETURN_STATUS,
 
   GET_RETURNS_SUCCESS,
 } from './constants';
@@ -37,7 +38,11 @@ const initialState = fromJS({
     itemId: '',
   },
   managingReturn: false,
-  returnItem: {},
+  returnItem: {
+    id: '',
+    type: '',
+  },
+  newStatus: '',
   returns: [],
 });
 
@@ -90,6 +95,9 @@ function custSupportAgentReducer(state = initialState, action) {
       return state
         .set('managingReturn', false)
         .set('returnItem', {});
+    case SET_RETURN_STATUS:
+      return state
+        .set('newStatus', action.status);
 
     default:
       return state;

--- a/react/app/containers/CustSupportAgent/reducer.js
+++ b/react/app/containers/CustSupportAgent/reducer.js
@@ -23,6 +23,8 @@ import {
   MANAGE_RETURN,
   CANCEL_MANAGE_RETURN,
   SET_RETURN_STATUS,
+  SET_RETURN_STATUS_SUCCESS,
+  RESOLVE_RETURN_SUCCESS,
 
   GET_RETURNS_SUCCESS,
 } from './constants';
@@ -40,7 +42,10 @@ const initialState = fromJS({
   managingReturn: false,
   returnItem: {
     id: '',
+    reason: '',
+    storeID: '',
     type: '',
+    itemID: '',
   },
   newStatus: '',
   returns: [],
@@ -90,14 +95,31 @@ function custSupportAgentReducer(state = initialState, action) {
     case MANAGE_RETURN:
       return state
         .set('managingReturn', true)
-        .set('returnItem', action.item);
+        .setIn(['returnItem', 'id'], action.item.id)
+        .setIn(['returnItem', 'reason'], action.item.reason)
+        .setIn(['returnItem', 'storeID'], action.item.storeID)
+        .setIn(['returnItem', 'type'], action.item.type)
+        .setIn(['returnItem', 'itemID'], action.item.itemID);
     case CANCEL_MANAGE_RETURN:
       return state
         .set('managingReturn', false)
-        .set('returnItem', {});
+        .setIn(['returnItem', 'id'], '')
+        .setIn(['returnItem', 'reason'], '')
+        .setIn(['returnItem', 'storeID'], '')
+        .setIn(['returnItem', 'type'], '')
+        .setIn(['returnItem', 'itemID'], '');
     case SET_RETURN_STATUS:
       return state
         .set('newStatus', action.status);
+    case SET_RETURN_STATUS_SUCCESS:
+      console.log('set return status success');
+      return state
+        .set('newStatus', '')
+        .setIn(['returnItem', 'type'], action.data.type);
+    case RESOLVE_RETURN_SUCCESS:
+      console.log('resolve return success', action.data);
+      return state
+        .setIn(['returnItem', 'type'], 'RESOLVED');
 
     default:
       return state;

--- a/react/app/containers/CustSupportAgent/reducer.js
+++ b/react/app/containers/CustSupportAgent/reducer.js
@@ -84,10 +84,12 @@ function custSupportAgentReducer(state = initialState, action) {
         .set('returns', action.data);
     case MANAGE_RETURN:
       return state
-        .set('managingReturn', true);
+        .set('managingReturn', true)
+        .set('returnItem', action.item);
     case CANCEL_MANAGE_RETURN:
       return state
-        .set('managingReturn', false);
+        .set('managingReturn', false)
+        .set('returnItem', {});
 
     default:
       return state;

--- a/react/app/containers/CustSupportAgent/sagas.js
+++ b/react/app/containers/CustSupportAgent/sagas.js
@@ -7,10 +7,14 @@ import request from 'utils/request';
 import {
   SUBMIT_RETURN,
   GET_RETURNS,
+  SET_RETURN_STATUS,
+  RESOLVE_RETURN,
 } from './constants';
 
 import {
   selectReturn,
+  selectManagedReturn,
+  selectNewStatus,
 } from './selectors';
 
 import {
@@ -134,9 +138,55 @@ export function* getReturnData() {
 }
 
 
+export function* setStatus() {
+  // Fill in
+  const managedReturn = yield select(selectManagedReturn());
+  const newStatus = yield select(selectNewStatus());
+
+  console.log('set status saga', managedReturn, newStatus);
+}
+
+export function* setStatusWatcher() {
+  while (yield take(SET_RETURN_STATUS)) {
+    yield call(setStatus);
+  }
+}
+
+export function* setStatusData() {
+  const watcher = yield fork(setStatusWatcher);
+
+  yield take(LOCATION_CHANGE);
+  yield cancel(watcher);
+  return;
+}
+
+export function* resolveReturn() {
+  // Fill in
+  const managedReturn = yield select(selectManagedReturn());
+
+  console.log('resolve saga', managedReturn);
+}
+
+export function* resolveReturnWatcher() {
+  while (yield take(RESOLVE_RETURN)) {
+    yield call(resolveReturn);
+  }
+}
+
+export function* resolveData() {
+  const watcher = yield fork(resolveReturnWatcher);
+
+  yield take(LOCATION_CHANGE);
+  yield cancel(watcher);
+  return;
+}
+
+
 // All sagas to be loaded
 export default [
   signOutData,
   returnData,
   getReturnData,
+  setStatusData,
+  resolveData,
 ];

--- a/react/app/containers/CustSupportAgent/sagas.js
+++ b/react/app/containers/CustSupportAgent/sagas.js
@@ -21,6 +21,11 @@ import {
   submitReturnSuccess,
   submitReturnError,
 
+  setRequestStatusError,
+  setRequestStatusSuccess,
+  resolveReturnError,
+  resolveReturnSuccess,
+
   getReturnsSuccess,
 } from './actions';
 
@@ -144,6 +149,29 @@ export function* setStatus() {
   const newStatus = yield select(selectNewStatus());
 
   console.log('set status saga', managedReturn, newStatus);
+  const requestURL = '/api/customer-support/requestStatus';
+
+  // Make the api call
+  const options = {
+    method: 'post',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ returnID: managedReturn.id, status: newStatus }),
+  };
+
+  // Call our request helper (see 'utils/request')
+  const returnRequest = yield call(request, requestURL, options);
+
+  console.log("Return api result");
+  console.log(returnRequest);
+
+  if (!returnRequest.err) {
+    yield put(setRequestStatusSuccess(returnRequest.data));
+  } else {
+    yield put(setRequestStatusError());
+  }
 }
 
 export function* setStatusWatcher() {
@@ -165,6 +193,29 @@ export function* resolveReturn() {
   const managedReturn = yield select(selectManagedReturn());
 
   console.log('resolve saga', managedReturn);
+  const requestURL = '/api/customer-support/resolve';
+
+  // Make the api call
+  const options = {
+    method: 'post',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ returnID: managedReturn.id, itemID: managedReturn.itemID }),
+  };
+
+  // Call our request helper (see 'utils/request')
+  const returnRequest = yield call(request, requestURL, options);
+
+  console.log("Return api result");
+  console.log(returnRequest);
+
+  if (!returnRequest.err) {
+    yield put(resolveReturnSuccess(returnRequest.data));
+  } else {
+    yield put(resolveReturnError());
+  }
 }
 
 export function* resolveReturnWatcher() {

--- a/react/app/containers/CustSupportAgent/selectors.js
+++ b/react/app/containers/CustSupportAgent/selectors.js
@@ -15,7 +15,7 @@ const selectReturn = () => createSelector(
 
 const selectManagedReturn = () => createSelector(
   selectCustSupportAgentDomain(),
-  (state) => state.get('returnItem')
+  (state) => state.get('returnItem').toJS()
 );
 
 const selectNewStatus = () => createSelector(

--- a/react/app/containers/CustSupportAgent/selectors.js
+++ b/react/app/containers/CustSupportAgent/selectors.js
@@ -13,6 +13,16 @@ const selectReturn = () => createSelector(
   (state) => state.get('newReturn').toJS()
 );
 
+const selectManagedReturn = () => createSelector(
+  selectCustSupportAgentDomain(),
+  (state) => state.get('returnItem')
+);
+
+const selectNewStatus = () => createSelector(
+  selectCustSupportAgentDomain(),
+  (state) => state.get('newStatus')
+);
+
 /**
  * Default selector used by CustSupportAgent
  */
@@ -26,4 +36,6 @@ export default selectCustSupportAgent;
 export {
   selectCustSupportAgentDomain,
   selectReturn,
+  selectManagedReturn,
+  selectNewStatus,
 };


### PR DESCRIPTION
The Customer Support UI is pretty much done now. Users can:
- enter returns
- update the return status for selected returns
- filter the table of returns for specific ones

There may be a few bugs that will need to be fixed in the future.